### PR TITLE
Release: v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the "View Charset" extension will be documented in this file.
 
+## [0.1.5] - 2026-02-21
+
+### Changed
+
+- Replaced `winston` logger with a lightweight custom implementation using only built-in Node.js `fs` and VS Code API
+  - Removed 26 transitive dependencies
+  - Fixed trailing space in log messages when no metadata is provided
+  - Fixed `Error` objects being serialized as `{}` — `message` and `stack` are now included
+  - Fixed `Logger.instance` not being reset after `dispose()`, preventing stale instance reuse on re-activation
+
+### Fixed
+
+- Added `.claude/settings.local.json` to `.gitignore` (per-developer local settings should not be version-controlled)
+
 ## [0.1.4] - 2026-02-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
   "icon": "images/icon.png",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "MIT",
   "publisher": "long-kudo",
   "repository": {


### PR DESCRIPTION
## v0.1.5 リリース

### Changed

- `winston` ロガーを軽量なカスタム実装に置き換え（Node.js 組み込みの `fs` と VS Code API のみ使用）
  - トランザティブ依存26パッケージを削除
  - メタデータなし時のログメッセージ末尾スペースを修正
  - `Error` オブジェクトが `{}` にシリアライズされるバグを修正（`message`/`stack` を含めるよう変更）
  - `dispose()` 後に `Logger.instance` がリセットされないバグを修正

### Fixed

- `.claude/settings.local.json` を `.gitignore` に追加

## Checklist

- [x] `npm run compile` 通過
- [ ] `npm run lint` 通過
- [ ] `npm test` 通過
- [ ] Marketplace 公開

🤖 Generated with [Claude Code](https://claude.com/claude-code)