### PR TITLE
Fix: align engines.vscode with @types/vscode version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/long-910/vscode-view-charset/issues"
   },
   "engines": {
-    "vscode": "^1.96.0",
+    "vscode": "^1.109.0",
     "node": ">=18.0.0"
   },
   "categories": [


### PR DESCRIPTION
## Summary

- `@types/vscode` was bumped to `^1.109.0` by Dependabot, but `engines.vscode` remained at `^1.96.0`
- This mismatch caused `vsce package` to fail with: `@types/vscode ^1.109.0 greater than engines.vscode ^1.96.0`
- Update `engines.vscode` to `^1.109.0` to match

## Test plan

- [ ] Run `vsce package` and verify it completes without the version mismatch error

🤖 Generated with [Claude Code](https://claude.com/claude-code)