### PR TITLE
Feat: add Open VSX publish CI and bump to v0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,3 +68,10 @@ jobs:
         with:
           pat: ${{ secrets.VSCE_PAT }}
           registryUrl: https://marketplace.visualstudio.com
+
+      - name: Publish to Open VSX
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.OPEN_VSX_PAT }}
+          registryUrl: https://open-vsx.org
+          extensionFile: ./*.vsix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the "View Charset" extension will be documented in this f
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-28
+
+### Added
+
+- Published to [Open VSX Registry](https://open-vsx.org/extension/long-kudo/vscode-view-charset): extension is now available for VSCodium and other Eclipse Theia-based editors
+- CI: added Open VSX publish step to `release.yml` (uses `OPEN_VSX_PAT` secret)
+- Added Open VSX version badge to all READMEs
+
 ## [0.1.6] - 2026-03-01
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -7,6 +7,7 @@
 [![VS Marketplace](https://img.shields.io/visual-studio-marketplace/v/long-kudo.vscode-view-charset?style=flat-square&logo=visualstudiocode&logoColor=white&label=Marketplace)](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset)
 [![Downloads](https://img.shields.io/visual-studio-marketplace/d/long-kudo.vscode-view-charset?style=flat-square&logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset)
 [![Rating](https://img.shields.io/visual-studio-marketplace/r/long-kudo.vscode-view-charset?style=flat-square&logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset)
+[![Open VSX](https://img.shields.io/open-vsx/v/long-kudo/vscode-view-charset?style=flat-square&logo=eclipseide&logoColor=white&label=Open%20VSX)](https://open-vsx.org/extension/long-kudo/vscode-view-charset)
 
 [![License: MIT](https://img.shields.io/github/license/long-910/vscode-view-charset?style=flat-square)](https://github.com/long-910/vscode-view-charset/blob/main/LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/long-910/vscode-view-charset/ci.yml?branch=main&style=flat-square&logo=githubactions&logoColor=white&label=CI)](https://github.com/long-910/vscode-view-charset/actions/workflows/ci.yml)

--- a/README.ko.md
+++ b/README.ko.md
@@ -7,6 +7,7 @@
 [![VS Marketplace](https://img.shields.io/visual-studio-marketplace/v/long-kudo.vscode-view-charset?style=flat-square&logo=visualstudiocode&logoColor=white&label=Marketplace)](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset)
 [![Downloads](https://img.shields.io/visual-studio-marketplace/d/long-kudo.vscode-view-charset?style=flat-square&logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset)
 [![Rating](https://img.shields.io/visual-studio-marketplace/r/long-kudo.vscode-view-charset?style=flat-square&logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset)
+[![Open VSX](https://img.shields.io/open-vsx/v/long-kudo/vscode-view-charset?style=flat-square&logo=eclipseide&logoColor=white&label=Open%20VSX)](https://open-vsx.org/extension/long-kudo/vscode-view-charset)
 
 [![License: MIT](https://img.shields.io/github/license/long-910/vscode-view-charset?style=flat-square)](https://github.com/long-910/vscode-view-charset/blob/main/LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/long-910/vscode-view-charset/ci.yml?branch=main&style=flat-square&logo=githubactions&logoColor=white&label=CI)](https://github.com/long-910/vscode-view-charset/actions/workflows/ci.yml)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![VS Marketplace](https://img.shields.io/visual-studio-marketplace/v/long-kudo.vscode-view-charset?style=flat-square&logo=visualstudiocode&logoColor=white&label=Marketplace)](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset)
 [![Downloads](https://img.shields.io/visual-studio-marketplace/d/long-kudo.vscode-view-charset?style=flat-square&logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset)
 [![Rating](https://img.shields.io/visual-studio-marketplace/r/long-kudo.vscode-view-charset?style=flat-square&logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset)
+[![Open VSX](https://img.shields.io/open-vsx/v/long-kudo/vscode-view-charset?style=flat-square&logo=eclipseide&logoColor=white&label=Open%20VSX)](https://open-vsx.org/extension/long-kudo/vscode-view-charset)
 
 [![License: MIT](https://img.shields.io/github/license/long-910/vscode-view-charset?style=flat-square)](https://github.com/long-910/vscode-view-charset/blob/main/LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/long-910/vscode-view-charset/ci.yml?branch=main&style=flat-square&logo=githubactions&logoColor=white&label=CI)](https://github.com/long-910/vscode-view-charset/actions/workflows/ci.yml)

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -7,6 +7,7 @@
 [![VS Marketplace](https://img.shields.io/visual-studio-marketplace/v/long-kudo.vscode-view-charset?style=flat-square&logo=visualstudiocode&logoColor=white&label=Marketplace)](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset)
 [![Downloads](https://img.shields.io/visual-studio-marketplace/d/long-kudo.vscode-view-charset?style=flat-square&logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset)
 [![Rating](https://img.shields.io/visual-studio-marketplace/r/long-kudo.vscode-view-charset?style=flat-square&logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset)
+[![Open VSX](https://img.shields.io/open-vsx/v/long-kudo/vscode-view-charset?style=flat-square&logo=eclipseide&logoColor=white&label=Open%20VSX)](https://open-vsx.org/extension/long-kudo/vscode-view-charset)
 
 [![License: MIT](https://img.shields.io/github/license/long-910/vscode-view-charset?style=flat-square)](https://github.com/long-910/vscode-view-charset/blob/main/LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/long-910/vscode-view-charset/ci.yml?branch=main&style=flat-square&logo=githubactions&logoColor=white&label=CI)](https://github.com/long-910/vscode-view-charset/actions/workflows/ci.yml)

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -7,6 +7,7 @@
 [![VS Marketplace](https://img.shields.io/visual-studio-marketplace/v/long-kudo.vscode-view-charset?style=flat-square&logo=visualstudiocode&logoColor=white&label=Marketplace)](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset)
 [![Downloads](https://img.shields.io/visual-studio-marketplace/d/long-kudo.vscode-view-charset?style=flat-square&logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset)
 [![Rating](https://img.shields.io/visual-studio-marketplace/r/long-kudo.vscode-view-charset?style=flat-square&logo=visualstudiocode&logoColor=white)](https://marketplace.visualstudio.com/items?itemName=long-kudo.vscode-view-charset)
+[![Open VSX](https://img.shields.io/open-vsx/v/long-kudo/vscode-view-charset?style=flat-square&logo=eclipseide&logoColor=white&label=Open%20VSX)](https://open-vsx.org/extension/long-kudo/vscode-view-charset)
 
 [![License: MIT](https://img.shields.io/github/license/long-910/vscode-view-charset?style=flat-square)](https://github.com/long-910/vscode-view-charset/blob/main/LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/long-910/vscode-view-charset/ci.yml?branch=main&style=flat-square&logo=githubactions&logoColor=white&label=CI)](https://github.com/long-910/vscode-view-charset/actions/workflows/ci.yml)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-view-charset",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-view-charset",
-      "version": "0.1.6",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "encoding-japanese": "^1.0.30",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
   "icon": "images/icon.png",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "license": "MIT",
   "publisher": "long-kudo",
   "repository": {


### PR DESCRIPTION
## Summary

- **Open VSX CI**: `release.yml` に `Publish to Open VSX` ステップを追加。タグプッシュ時に VS Marketplace と同時に Open VSX Registry へも公開する（`OPEN_VSX_PAT` シークレットを使用）
- **Open VSX バッジ**: 全 README（en / ja / zh-cn / zh-tw / ko）に Open VSX バッジを追加
- **バージョン**: `0.1.6` → `0.2.0`（マイナーバージョンアップ）
- **CHANGELOG**: `[0.2.0] - 2026-05-28` セクションを追加

## Note

`OPEN_VSX_PAT` シークレットはリポジトリに設定済みであること（ユーザー確認済み）。