### PR TITLE
Fix: use OVSX_PAT secret name for Open VSX publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,6 @@ jobs:
       - name: Publish to Open VSX
         uses: HaaLeo/publish-vscode-extension@v2
         with:
-          pat: ${{ secrets.OPEN_VSX_PAT }}
+          pat: ${{ secrets.OVSX_PAT }}
           registryUrl: https://open-vsx.org
           extensionFile: ./*.vsix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to the "View Charset" extension will be documented in this f
 ### Added
 
 - Published to [Open VSX Registry](https://open-vsx.org/extension/long-kudo/vscode-view-charset): extension is now available for VSCodium and other Eclipse Theia-based editors
-- CI: added Open VSX publish step to `release.yml` (uses `OPEN_VSX_PAT` secret)
+- CI: added Open VSX publish step to `release.yml` (uses `OVSX_PAT` secret)
 - Added Open VSX version badge to all READMEs
 
 ## [0.1.6] - 2026-03-01


### PR DESCRIPTION
## Summary

- `release.yml` と `CHANGELOG.md` のシークレット名 `OPEN_VSX_PAT` → `OVSX_PAT` に修正
- #45 のマージ時に修正コミットが取り込まれなかったため、追加修正