### PR TITLE
CI: add manual Open VSX publish workflow (workflow_dispatch)

### DIFF
--- a/.github/workflows/openvsx-publish.yml
+++ b/.github/workflows/openvsx-publish.yml
@@ -1,0 +1,29 @@
+name: Publish to Open VSX
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v0.2.0)"
+        required: true
+
+jobs:
+  publish:
+    name: Publish to Open VSX Registry
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download .vsix from GitHub Release
+        run: |
+          gh release download "${{ github.event.inputs.tag }}" \
+            --pattern "*.vsix" \
+            --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to Open VSX
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.OVSX_PAT }}
+          registryUrl: https://open-vsx.org
+          extensionFile: ./*.vsix


### PR DESCRIPTION
## Summary

- `openvsx-publish.yml` を追加: `workflow_dispatch` で任意のタグの Open VSX 公開を単独実行できる
- GitHub Release に添付済みの `.vsix` を `gh release download` で取得して Open VSX に公開
- タグ打ち済みのリリースに対しても Actions タブから再実行可能

## 使い方

Actions → **Publish to Open VSX** → **Run workflow** → タグ名（例: `v0.2.0`）を入力して実行