### PR TITLE
Fix: resolve .vsix path explicitly instead of glob for Open VSX publish

### DIFF
--- a/.github/workflows/openvsx-publish.yml
+++ b/.github/workflows/openvsx-publish.yml
@@ -21,9 +21,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Find .vsix path
+        id: vsix
+        run: echo "path=$(ls *.vsix)" >> $GITHUB_OUTPUT
+
       - name: Publish to Open VSX
         uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.OVSX_PAT }}
           registryUrl: https://open-vsx.org
-          extensionFile: ./*.vsix
+          extensionFile: ${{ steps.vsix.outputs.path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,13 @@ jobs:
           pat: ${{ secrets.VSCE_PAT }}
           registryUrl: https://marketplace.visualstudio.com
 
+      - name: Find .vsix path
+        id: vsix
+        run: echo "path=$(ls *.vsix)" >> $GITHUB_OUTPUT
+
       - name: Publish to Open VSX
         uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.OVSX_PAT }}
           registryUrl: https://open-vsx.org
-          extensionFile: ./*.vsix
+          extensionFile: ${{ steps.vsix.outputs.path }}


### PR DESCRIPTION
## Summary

`HaaLeo/publish-vscode-extension@v2` は `extensionFile` でグロブを展開しないため、`./*.vsix` を渡すと `ENOENT` エラーになる。

`ls *.vsix` で実際のファイル名を取得し、そのパスを渡すよう修正。

- `openvsx-publish.yml` を修正（手動実行ワークフロー）
- `release.yml` も同様に修正（タグ時の自動実行ワークフロー）

## 変更内容

```yaml
- name: Find .vsix path
  id: vsix
  run: echo "path=$(ls *.vsix)" >> $GITHUB_OUTPUT

- name: Publish to Open VSX
  uses: HaaLeo/publish-vscode-extension@v2
  with:
    extensionFile: ${{ steps.vsix.outputs.path }}
```